### PR TITLE
Add Device endpoints

### DIFF
--- a/backend/src/__mocks__/@prisma/client.ts
+++ b/backend/src/__mocks__/@prisma/client.ts
@@ -1,6 +1,9 @@
 export const mockCategoryFindMany = jest.fn()
 export const mockDeleteCategory = jest.fn()
 export const mockCreateCategory = jest.fn()
+export const mockDeviceFindMany = jest.fn()
+export const mockDeviceCreate = jest.fn()
+export const mockDeviceDelete = jest.fn()
 
 export const PrismaClient = jest.fn().mockImplementation(() => {
   return {
@@ -8,6 +11,12 @@ export const PrismaClient = jest.fn().mockImplementation(() => {
       findMany: mockCategoryFindMany,
       delete: mockDeleteCategory,
       create: mockCreateCategory,
+    },
+    device: {
+      findMany: mockDeviceFindMany,
+      create: mockDeviceCreate,
+      delete: mockDeviceDelete
     }
   }
 })
+

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,6 +1,7 @@
 import express, { Application } from 'express';
 
-import categoryRoutes from './category/routes';
+import categoryRoutes from './category'
+import deviceRoutes from './device';
 
 const app: Application = express();
 const port = process.env.PORT || 8000;
@@ -8,6 +9,7 @@ const port = process.env.PORT || 8000;
 app.use(express.json());
 
 app.use('/category', categoryRoutes);
+app.use('/device', deviceRoutes);
 
 app.get('/', (req, res) => {
   res.send('Welcome to Express & Typecsript Server')

--- a/backend/src/category/__tests__/controller.test.ts
+++ b/backend/src/category/__tests__/controller.test.ts
@@ -2,7 +2,7 @@ jest.mock("@prisma/client")
 import { Request, Response } from "express"
 import CategoryController from "../controller"
 import CategoryService from "../service"
-import { mockCategoryFindMany, mockCreateCategory, mockDeleteCategory } from "../__mocks__/@prisma/client"
+import { mockCategoryFindMany, mockCreateCategory, mockDeleteCategory } from "../../__mocks__/@prisma/client"
 
 const categoryService = new CategoryService()
 const categoryController = new CategoryController(categoryService)

--- a/backend/src/category/__tests__/service.test.ts
+++ b/backend/src/category/__tests__/service.test.ts
@@ -1,6 +1,6 @@
 jest.mock("@prisma/client")
 import CategoryService from "../service";
-import { mockCategoryFindMany, mockDeleteCategory, mockCreateCategory } from "../__mocks__/@prisma/client";
+import { mockCategoryFindMany, mockDeleteCategory, mockCreateCategory } from "../../__mocks__/@prisma/client";
 
 
 // jest.mock("@prisma/client", () => {

--- a/backend/src/device/__tests__/controller.test.ts
+++ b/backend/src/device/__tests__/controller.test.ts
@@ -1,0 +1,83 @@
+jest.mock("@prisma/client")
+import { Response, Request } from "express";
+import DeviceController from "../controller";
+import DeviceService from "../service";
+import { mockDeviceCreate, mockDeviceDelete, mockDeviceFindMany } from "../../__mocks__/@prisma/client";
+
+const deviceService = new DeviceService()
+const deviceController = new DeviceController(deviceService)
+
+describe("DeviceController", () => {
+  it("should response all devices available", async () => {
+    const mockDevices = [
+      {
+        id: 1,
+        color: 'orange',
+        partNumber: 100,
+        categoryId: 1
+      },
+      {
+        id: 2,
+        color: 'red',
+        partNumber: 101,
+        categoryId: 1
+      }
+    ]
+    mockDeviceFindMany.mockResolvedValue(mockDevices);
+
+    const mreq = {} as Request
+    const mres = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response
+
+    await deviceController.getAllDevices(mreq, mres)
+    
+    expect(mres.status).toHaveBeenCalledWith(200)
+    expect(mres.json).toHaveBeenCalledWith(mockDevices)
+  })
+
+  it("should response the new device created", async () => {
+    const mockDevice = {
+      id: 1,
+      color: 'red',
+      partNumber: 102,
+      categoryId: 1
+    }
+
+    const mreq = {
+      body: {
+        color: mockDevice.color,
+        partNumber: mockDevice.partNumber,
+        categoryId: mockDevice.categoryId
+      }
+    } as Request
+    const mres = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response
+    
+    mockDeviceCreate.mockResolvedValue(mockDevice);
+    await deviceController.createDevice(mreq, mres)
+
+    expect(mres.status).toHaveBeenCalledWith(200)
+    expect(mres.json).toHaveBeenCalledWith(mockDevice)
+  })
+
+  it("should response the deleted device", async () => {
+    const mockDevice = {
+      id: 1,
+      color: 'red',
+      partNumber: 102,
+      categoryId: 1
+    }
+
+    const mreq = {
+      params: {
+        id: 1,
+      }
+    } as unknown as Request
+    const mres = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response
+
+    mockDeviceDelete.mockResolvedValue(mockDevice);
+
+    await deviceController.deleteDevice(mreq, mres)
+
+    expect(mres.status).toHaveBeenCalledWith(200)
+    expect(mres.json).toHaveBeenCalledWith(mockDevice)
+  })
+})

--- a/backend/src/device/__tests__/schema.test.ts
+++ b/backend/src/device/__tests__/schema.test.ts
@@ -1,0 +1,31 @@
+import { createDeviceSchema, deleteDeviceSchema } from "../schema";
+
+describe("Device Schema Validation", () => {
+  it("should pass for valid create device body data", () => {
+    const mockBody = { color: "orange", partNumber: 101, categoryId: 1 }
+    expect(() => createDeviceSchema.request.body.parse(mockBody)).not.toThrow();
+  });
+
+    it("should fail for missing properties on create device body", () => {
+      expect(() => createDeviceSchema.request.body.parse({})).toThrow();
+    });
+  
+    it("should fail for invalid color type on create category body", () => {
+      const mockBody = { color: 123, partNumber: 101, categoryId: 1 }
+      expect(() => createDeviceSchema.request.body.parse(mockBody)).toThrow();
+    });
+  
+    it("should pass for valid delete device params", () => {
+      const mockParams = { id: 1 }
+      expect(() => deleteDeviceSchema.request.params.parse(mockParams)).not.toThrow();
+    })
+  
+    it("should fail for missing id on delete device params", () => {
+      expect(() => deleteDeviceSchema.request.params.parse({})).toThrow();
+    });
+  
+    it("should fail for invalid id type on delete device params", () => {
+      const mockBody = { id: "id01" }
+      expect(() => deleteDeviceSchema.request.params.parse(mockBody)).toThrow();
+    });
+})

--- a/backend/src/device/__tests__/service.test.ts
+++ b/backend/src/device/__tests__/service.test.ts
@@ -1,0 +1,48 @@
+jest.mock("@prisma/client")
+import DeviceService from "../service"
+import { mockDeviceCreate, mockDeviceDelete, mockDeviceFindMany } from "../../__mocks__/@prisma/client"
+
+const deviceService = new DeviceService()
+
+describe("DeviceService", () => {
+  it("should return all devices from the database", async () => {
+    const mockDevices = [{ id: 1, color: 'orange', partNumber: 10, categoryid: 1 }]
+    mockDeviceFindMany.mockResolvedValue(mockDevices)
+
+    const devices = await deviceService.findAll();
+
+
+    expect(devices).toEqual(mockDevices);
+  })
+
+  it("should create a new device in the database and return it", async() => {
+    const mockDevice = {
+      id: 1,
+      color: 'orange',
+      partNumber: 10,
+      categoryId: 1,
+    }
+    mockDeviceCreate.mockResolvedValue(mockDevice);
+    const device = await deviceService.create(mockDevice.color, mockDevice.partNumber, mockDevice.categoryId)
+
+    expect(device).toEqual(mockDevice);
+    expect(mockDeviceCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it("should delete a device from the database", async () => {
+    const mockDevice = {
+      id: 1,
+      color: 'orange',
+      partNumber: 10,
+      categoryId: 1
+    }
+
+    mockDeviceDelete.mockResolvedValue(mockDevice)
+
+    const device = await deviceService.delete(mockDevice.id);
+
+    expect(device).toEqual(mockDevice);
+    expect(mockDeviceDelete).toHaveBeenCalledTimes(1);
+
+  })
+})

--- a/backend/src/device/controller.ts
+++ b/backend/src/device/controller.ts
@@ -1,0 +1,31 @@
+import { Request, Response } from "express";
+import DeviceService from "./service";
+
+class DeviceController {
+  constructor(private deviceService: DeviceService) {
+    this.deviceService = deviceService
+    this.getAllDevices = this.getAllDevices.bind(this);
+    this.createDevice = this.createDevice.bind(this);
+    this.deleteDevice = this.deleteDevice.bind(this);
+  }
+
+  async getAllDevices(req: Request, res: Response) {
+    const devices = await this.deviceService.findAll()
+
+    res.status(200).json(devices);
+  }
+
+  async createDevice(req: Request, res: Response) {
+    const { color, partNumber, categoryId } = req.body
+    const device = await this.deviceService.create(color, partNumber, categoryId);
+    res.status(200).json(device);
+  }
+
+  async deleteDevice(req: Request, res: Response) {
+    const id = parseInt(req.params.id);
+    const device = await this.deviceService.delete(id);
+    res.status(200).json(device); 
+  }
+}
+
+export default DeviceController;

--- a/backend/src/device/index.ts
+++ b/backend/src/device/index.ts
@@ -1,0 +1,3 @@
+import deviceRoutes from './routes'
+
+export default deviceRoutes;

--- a/backend/src/device/routes.ts
+++ b/backend/src/device/routes.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import CategoryController from '../category/controller';
+import DeviceService from './service';
+import DeviceController from './controller';
+import { requestValidation } from '../handlers/requestValidator';
+import { createDeviceSchema, deleteDeviceSchema } from './schema';
+
+
+const router = Router();
+
+const deviceService = new DeviceService()
+const deviceController = new DeviceController(deviceService)
+
+router.get('/', deviceController.getAllDevices)
+router.post('/', requestValidation(createDeviceSchema.request), deviceController.createDevice)
+router.delete('/:id', requestValidation(deleteDeviceSchema.request),  deviceController.deleteDevice)
+
+export default router;

--- a/backend/src/device/schema.ts
+++ b/backend/src/device/schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+
+export const createDeviceSchema = {
+  request: {
+    body: z.object({
+      color: z.string().max(16),
+      partNumber: z.number().int().positive(),
+      categoryId: z.number().int()
+    })
+  }
+}
+
+export const deleteDeviceSchema = {
+  request: {
+    params: z.object({
+      id: z.coerce.number().int()
+    })
+  }
+}

--- a/backend/src/device/service.ts
+++ b/backend/src/device/service.ts
@@ -1,0 +1,35 @@
+import { PrismaClient } from '@prisma/client'
+
+const prismaClient = new PrismaClient()
+
+class DeviceService {
+
+  async findAll() {
+    const devices = await prismaClient.device.findMany();
+    return devices
+  }
+
+  async create(color: string, partNumber: number, categoryId: number) {
+    const device = await prismaClient.device.create({
+      data: {
+        color,
+        partNumber,
+        categoryId
+      }
+    });
+
+    return device
+  }
+
+  async delete(id: number) {
+    const device = await prismaClient.device.delete({
+      where: {
+        id,
+      }
+    });
+
+    return device
+  } 
+}
+
+export default DeviceService;


### PR DESCRIPTION
## Description
- The device module was created, then three `/device` endpoints were added:
1. To get all devices
2. To create a new device
3. To delete a specific device

- ZOD schemas were added to validate the endpoints that create and delete a device.
- Unit tests were added to the device module's service, controller, and schema.

## Tests
- Create a new device
![image](https://github.com/user-attachments/assets/c389dded-bbf0-4d2b-9870-8a94374ce874)

- Get all devices from the database
![image](https://github.com/user-attachments/assets/fe729d4c-5ec9-467d-ba38-af7d2f347ea1)

- Deleting a device
- Delete the device
![image](https://github.com/user-attachments/assets/5f3af308-2c6e-4b36-b4c8-b39b4a81f7c4)
- Getting all devices after the delete 
![image](https://github.com/user-attachments/assets/34514813-27c5-49d3-9127-763e7a38e252)

- Unit Tets
![image](https://github.com/user-attachments/assets/ad0ef107-3a10-4748-b426-aac7f8d78376)

