### PR TITLE
Handling category deleting errors

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,11 +1,12 @@
 import express, { Application } from 'express';
-
+import cors from 'cors';
 import categoryRoutes from './category'
 import deviceRoutes from './device';
 
 const app: Application = express();
 const port = process.env.PORT || 8000;
 
+app.use(cors())
 app.use(express.json());
 
 app.use('/category', categoryRoutes);

--- a/backend/src/category/controller.ts
+++ b/backend/src/category/controller.ts
@@ -22,9 +22,14 @@ class CategoryController {
   }
 
   async deleteCategory(req: Request, res: Response) {
-    const id = parseInt(req.params.id)
-    const category = await this.categoryService.delete(id)
-    res.status(200).json(category)
+    const { id } = req.params;
+    
+    try {
+      const category = await this.categoryService.delete(Number(id));
+      res.status(204).json(category); // Sucesso, sem conteúdo
+    } catch (e: any) {
+      res.status(400).json({ error: e.message });
+    }
   }
 }
 

--- a/backend/src/category/service.ts
+++ b/backend/src/category/service.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client'
+import { Prisma, PrismaClient } from '@prisma/client'
 const prisma = new PrismaClient()
 
 class CategoryService {
@@ -15,12 +15,22 @@ class CategoryService {
   }
 
   async delete(id: number) {
-    return await prisma.category.delete({
-      where: {
-        id,
+    try {
+      return await prisma.category.delete({
+        where: {
+          id,
+        }
+      })
+    } catch(e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError) {
+        // The .code property can be accessed in a type-safe manner
+        if (e.code === 'P2003') {
+          throw new Error(`Cannot delete category because it is in use.`);
+        }
       }
-    })
+      throw e
+    }
   }
 }
 
-export default CategoryService;
+export default CategoryService


### PR DESCRIPTION
### Description
- The cors it was not added before, therefore, the frontend was not able to fetch data from the backend
- When we attempt to delete a category that is being used by a Device, Prisma throws an error, so an error handling it was added to the delete endpoint, which helped the frontend to handle the error as well.