### PR TITLE
chore(backend): use local tsc instead of npx tsc

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "build": "npx tsc",
+    "build": "NODE_ENV=production tsc",
     "start": "node dist/app.js",
     "dev": "nodemon",
     "test": "jest"


### PR DESCRIPTION
### Description
- To avoid some issues while deploying the backend on EC2, the build command was changed from `npx tsc` to the local `tsc` with the command `NODE_ENV=production tsc`